### PR TITLE
change activity type to released

### DIFF
--- a/.github/workflows/slab_integration.yml
+++ b/.github/workflows/slab_integration.yml
@@ -2,7 +2,7 @@ name: Automation for release on slab
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   create-update_slab_post:


### PR DESCRIPTION
shouldn't publish release on slab when pre-release